### PR TITLE
`sdcadm post-setup ha-binder` should use /usr/sbin/tar for the zookeeper backup.

### DIFF
--- a/lib/steps/zookeeper.js
+++ b/lib/steps/zookeeper.js
@@ -214,7 +214,7 @@ function backupZKData(opts, callback) {
                     '(this may take some time)');
             execRemoteOnVm({
                 cmd: 'cd /zookeeper/zookeeper; ' +
-                    '/opt/local/bin/tar czf zookeeper-' + ctx.stamp +
+                    '/usr/sbin/tar czf zookeeper-' + ctx.stamp +
                     '.tgz version-2',
                 vm_uuid: ctx._1stVm.uuid,
                 server_uuid: ctx._1stVm.server_uuid,
@@ -347,7 +347,7 @@ function replaceZKData(opts, callback) {
                 vm.uuid + ' (may take some time)');
             execRemoteOnVm({
                 cmd: 'cd /zookeeper/zookeeper; ' +
-                    '/opt/local/bin/tar xf zookeeper-' +
+                    '/usr/sbin/tar xf zookeeper-' +
                     ctx.stamp + '.tgz',
                 vm_uuid: vm.uuid,
                 server_uuid: vm.server_uuid,


### PR DESCRIPTION
 ```
 sdcadm post-setup ha-binder -y headnode UUID1 UUID2
 ```
 Fails with a cryptic assertion error from node. Upon further investigation:
 ```
 tail -100 /var/log/sdcadm/logs/* | bunyan
 ```
 It appears that `lib/steps/zookeeper.js` has a non-existent path to tar.
 `/opt/local/bin/tar` which does not exist in image: 
  `a0a5f9a7-14a4-41d2-bdcd-c9b0180d5ed1`.

 `/usr/sbin/tar` does exist. This PR simply updates the path to an existing tar 
 so that the ha-binder setup job can run properly.