### PR TITLE
TRITON-2179 ufds tls cert should be persistent across reprovisions

### DIFF
--- a/lib/cli/do_update_other.js
+++ b/lib/cli/do_update_other.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2021 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /* eslint-disable callback-return */
@@ -39,6 +40,29 @@ var SERVICE_BLACKLIST = ['cabase', 'cainstsvc'];
  * we need to.
  */
 var NEW_SERVICES = ['papi', 'mahi', 'cns', 'portolan', 'docker'];
+
+/*
+ * These services should have a delegated dataset. During update-other we will
+ * ensure the service has params.delegate_dataset = true. If this param is set,
+ * then during reprovisioning instances will be checked for a delegated dataset
+ * and one will be added if it is missing.
+ */
+var WANT_DELEGATED_DATASET = [
+    'amonredis',
+    'assets',
+    'binder',
+    'cloudapi',
+    'cmon',
+    'cns',
+    'docker',
+    'fwapi',
+    'imgapi',
+    'mahi',
+    'manatee',
+    'moray',
+    'sapi',
+    'ufds'
+]
 
 /*
  * The 'sdcadm experimental update-other' CLI subcommand.
@@ -436,6 +460,28 @@ function do_update_other(subcmd, opts, args, cb) {
                         action: 'delete',
                         params: paramUpdates
                     }, errors.sdcClientErrWrap(nextSvc, 'sapi'));
+                }
+            }, next);
+        },
+
+        function ensureServicesWantDelegatedDataset(ctx, next) {
+            vasync.forEachParallel({
+                inputs: ctx.svcs,
+                func: function updateSvc(svc, nextSvc) {
+                    if (WANT_DELEGATED_DATASET.indexOf(svc.name) !== -1 &&
+                        svc.type === 'vm' && svc.params &&
+                        svc.params.delegate_dataset !== true) {
+                        progress(
+                            'Add delegated dataset to  "%s" service ' +
+                            'definition. Dataset will be created on the next ' +
+                            'reprovision.',
+                            svc.name);
+                        updateService(svc.uuid,
+                            { params: { delegate_dataset: true } },
+                            nextSvc);
+                        return;
+                    }
+                    nextSvc();
                 }
             }, next);
         },

--- a/lib/cli/do_update_other.js
+++ b/lib/cli/do_update_other.js
@@ -62,7 +62,7 @@ var WANT_DELEGATED_DATASET = [
     'moray',
     'sapi',
     'ufds'
-]
+];
 
 /*
  * The 'sdcadm experimental update-other' CLI subcommand.


### PR DESCRIPTION
So, how is this going to work?

There's already a procedure, during instance reprovisions to add a delegated dataset if the sapi service has `params.delegate_dataset=true`. This PR updates `sdcadm experimental update-other` to add that parameter to UFDS. Incidentally, this also introduces a new mechanism to add delegated datasets to arbitrary services simply by expanding the new `WANT_DELEGATED_DATASET` array. For completeness, I added all services that already have delegated datasets, not just ones that need it added post-create.

See also the following companion PRs to complete TRITON-2179:

* TritonDataCenter/sdc-headnode#68
* TritonDataCenter/sdc-ufds#24