### PR TITLE
LINUXCN-23 Account for node.config location on LinuxCN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,15 @@
 
 <!--
     Copyright 2021 Joyent, Inc.
-    Copyright 2022 MNX Cloud, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # sdcadm Changelog
+
+## 1.39.0
+
+- LINUXCN-23 Account for node.config location on LinuxCN
+
 
 ## 1.38.0
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
-    Copyright 2022 MNX Cloud, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 
 -->
 
 # sdcadm
 
-This repository is part of the Joyent Triton project. See the [contribution
-guidelines](https://github.com/joyent/triton/blob/master/CONTRIBUTING.md)
+This repository is part of the Triton DataCenter project. See the [contribution
+guidelines](https://github.com/TritonDataCenter/triton/blob/master/CONTRIBUTING.md)
 and general documentation at the main
-[Triton project](https://github.com/joyent/triton) page.
+[Triton project](https://github.com/TritonDataCenter/triton) page.
 
 `sdcadm` is a tool that lives in the Triton headnode's GZ, for
 handling post-setup (i.e. setup steps after initial headnode setup),
@@ -28,14 +28,14 @@ Please see the [index](./docs/index.md) for more details.
 # Current status
 
 While `sdcadm` is still under significant development, and is far from complete,
-it is currently the recommended way to update SDC. Signs of incompleteness are
-that sub-commands of `sdcadm experimental ...` are required as part of the upgrade
-process.
+it is currently the recommended way to update Triton. Signs of incompleteness
+are that sub-commands of `sdcadm experimental ...` are required as part of the
+upgrade process.
 
 # Triton post-setup with sdcadm
 
-The document [post-setup](docs/post-setup.md) details the required steps in order to
-configure Triton DataCenter for practical usage, like HA setup and the
+The document [post-setup](docs/post-setup.md) details the required steps in
+order to configure Triton DataCenter for practical usage, like HA setup and the
 addition of services not installed by default.
 
 # Manage Triton upgrades with sdcadm

--- a/lib/cli/do_update_agents.js
+++ b/lib/cli/do_update_agents.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 'use strict';
 
@@ -815,16 +816,25 @@ UpdateAgents.prototype.exec = function exec(callback) {
                 '       exit 33',
                 '   fi',
                 '',
+
+                /*
+                 * Config dir exists in different location on Linux
+                 */
+                '   node_config=/opt/smartdc/config',
+                '   if [[ "$(uname -s)" == "Linux" ]]; then',
+                '       node_config=/usr/triton/config',
+                '   fi',
+                '',
                 /*
                  * Exit non zero if config dir does not exist
                  */
-                '   if [[ ! -d  /opt/smartdc/config && -z "$IS_CN" ]]; then',
-                '       echo "missing /opt/smartdc/config" >&2',
+                '   if [[ ! -d "$node_config" && -z "$IS_CN" ]]; then',
+                '       echo "missing $node_config" >&2',
                 '       exit 44',
                 '   fi',
                 '',
                 '   /usr/bin/cp /var/tmp/node.config/node.config ' +
-                    '/opt/smartdc/config/',
+                    '"$node_config"',
                 'fi',
                 '',
                 'echo "replaced node.config" >&2',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcadm",
   "description": "Administer a Triton Data Center",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
`sdcadm experimental update-agents` currently fails on Linux CNs with the error: `error (missing /opt/smartdc/config)`

`node.config` exists in `/usr/triton/config` on Linux CN's and `/opt/smartdc/config` on SmartOS CNs

# Testing

After making this change, `update-agents` proceeds further on a Linux CN and still succeeds successfully on SmartOS.

In order for `update-agents` to succeed completely on a Linux CN other changes are being made to other Triton repos, but this is the only change identified for `sdcadm`.
